### PR TITLE
Filesource plugin working with external files

### DIFF
--- a/assets/plugins/filesource/lang/english.inc.php
+++ b/assets/plugins/filesource/lang/english.inc.php
@@ -1,2 +1,3 @@
 <?php
 $_lang["Static file path"] = 'Static file path';
+$_lang["Static file hint"] = 'Relative to ';

--- a/assets/plugins/filesource/lang/german.inc.php
+++ b/assets/plugins/filesource/lang/german.inc.php
@@ -1,2 +1,3 @@
 <?php
 $_lang["Static file path"] = 'Statischer Dateipfad';
+$_lang["Static file hint"] = 'Relativ zu ';

--- a/assets/plugins/filesource/lang/russian-UTF8.inc.php
+++ b/assets/plugins/filesource/lang/russian-UTF8.inc.php
@@ -1,2 +1,3 @@
 <?php
 $_lang["Static file path"] = 'Привязанный файл';
+$_lang["Static file hint"] = 'Относительно ';

--- a/assets/plugins/filesource/plugin.filesource.php
+++ b/assets/plugins/filesource/plugin.filesource.php
@@ -2,18 +2,26 @@
 /**
  * FileSource
  *
- * Save snippets and plugins to static files
+ * Save snippets and plugins to static files.
+ * 
+ * Adds an input filed for the file path to save to in the properties tab of every plugin or snippet. The path must be specified
+ * relative to the respective element folder (i.e. assets/plugins or assets/snippets). By default, only files located in those
+ * folders are allowed. If you wish to include files from outside of these folders, set the configuration option "Allow files
+ * outside of default folders" of the filesource plugin to true: The file path must still be specified relative to the default
+ * folders, but going up the folder tree is now allowed (e.g. ../../myfile.php) will point to a file in the root of the MODx
+ * installation.
  *
  * @category    plugin
- * @version     0.1
- * @internal    @properties
+ * @version     0.2
+ * @internal    @properties &allow_files_from_outside=Allow files outside of default folders;list;true,false;false
  * @internal    @events OnSnipFormRender,OnBeforeSnipFormSave,OnSnipFormPrerender,OnPluginFormPrerender,OnPluginFormRender,OnBeforePluginFormSave
  * @internal    @modx_category Manager and Admin
  * @internal    @installset base
  * @reportissues https://github.com/modxcms/evolution
  * @author      Maxim Mukharev
  * @author      By Carw, and Bumkaka
- * @lastupdate  06/05/2016
+ * @author		kabachello
+ * @lastupdate  17/01/2017
  */
 if(!defined('MODX_BASE_PATH')) die('What are you doing? Get out of here!');
 
@@ -43,7 +51,7 @@ if($modx->event->name==='OnBeforePluginFormSave' || $modx->event->name==='OnBefo
     {
         $filebinding = trim($modx->db->escape($_POST['filebinding']));
         if(strpos($filebinding,'\\')) $filebinding = str_replace('\\','/',$filebinding);
-        if(strpos($filebinding,'../')!==false || substr($filebinding,0,1)==='/')
+		if((!$allow_files_from_outside && strpos($filebinding,'../')!==false) || substr($filebinding,0,1)==='/')
             $has_filebinding = '0';
         elseif(!empty($filebinding))
         {
@@ -114,9 +122,10 @@ switch ($modx->event->name)
 mE1   = new Element("tr");
 mE11  = new Element("th",{"align":"left","styles":{"padding-top":"14px"}});
 mE12  = new Element("td",{"align":"left","styles":{"padding-top":"14px"}});
-mE122 = new Element("input",{"name":"filebinding","type":"text","maxlength":"75","value":"'.$content['file_binding'].'","class":"inputBox","styles":{"width":"300px"},"events":{"change":function(){documentDirty=true;}}});
+mE122 = new Element("input",{"name":"filebinding","type":"text","maxlength":"90","value":"'.$content['file_binding'].'","class":"inputBox","styles":{"width":"300px"},"events":{"change":function(){documentDirty=true;}}});
 
-mE11.appendText("' . _lang('Static file path') . '");
+
+mE11.appendText("' . _lang('Static file path') . ' (' . _lang('Static file hint') . 'assets/' . $elm_name . '/)");
 mE11.inject(mE1);
 mE122.inject(mE12);
 mE12.inject(mE1);

--- a/install/assets/plugins/filesource.tpl
+++ b/install/assets/plugins/filesource.tpl
@@ -5,10 +5,11 @@
  * Save snippet and plugins to file
  *
  * @category    plugin
- * @version     0.1
+ * @version     0.2
  * @author		By Carw, and Bumkaka
  * @internal    @properties 
  * @internal    @events OnSnipFormRender,OnBeforeSnipFormSave,OnSnipFormPrerender,OnPluginFormPrerender,OnPluginFormRender,OnBeforePluginFormSave
+ * @internal    @properties &allow_files_from_outside=Allow files outside of default folders;list;true,false;false
  * @internal    @modx_category Manager and Admin
  * @internal    @installset base
  */


### PR DESCRIPTION
New option in the filesource plugin to accept paths to outside of the
default snippet and plugin folders (off by default, in order not to change existing plugin behavior)

Новая опция добавлена в плагин filesource, позволяющая хранить файлы вне стандартных папок. Это полезно, если нужно подключать что-то (большое), что лежит рядом с MODx. Так у меня есть крупный проект, которому нужен внешний CMS. Я написал коннектор для MODx, но этот коннектор лежит в папках проекта и в его репозитории. Чтобы не копировать необходимые сниппеты и плагины туда-сюда, удобно их сотавить в папке проекта и просто подгружать в MODx.

Новая опция отключаемая и по-умолчанию выключена. Настройки в параметрах плагина. В инсталлятор их тоже добавил.