### PR TITLE
FIX typo in SQL n modManagers-API

### DIFF
--- a/assets/lib/MODxAPI/modManagers.php
+++ b/assets/lib/MODxAPI/modManagers.php
@@ -272,7 +272,7 @@ class modManagers extends MODxAPI
             if ($value == '' || !$this->isChanged($key)) {
                 continue;
             }
-            $result = $this->query("SELECT `setting_value` FROM {$this->makeTable('web_user_settings')} WHERE `user` = '{$this->id}' AND `setting_name` = '{$key}'");
+            $result = $this->query("SELECT `setting_value` FROM {$this->makeTable('user_settings')} WHERE `user` = '{$this->id}' AND `setting_name` = '{$key}'");
             if ($this->modx->db->getRecordCount($result) > 0) {
                 $this->query("UPDATE {$this->makeTable('user_settings')} SET `setting_value` = '{$value}' WHERE `user` = '{$this->id}' AND `setting_name` = '{$key}';");
             } else {


### PR DESCRIPTION
Surely just a typo: the web_user_settings was used at one place in modManagers.